### PR TITLE
Add device choice list and playback controls.

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -63,7 +63,11 @@
   import Login from './components/Login'
   import LoginService from './services/LoginService'
   import UserService from './services/UserService'
+  import WebPlaybackService from './services/WebPlaybackService'
   import UserPhoto from './components/UserPhoto'
+
+  // I'm not 100% sold that this is the right place. It seems to be the first place with service imports available.
+  WebPlaybackService.initializeWebPlaybackSDK()
 
   export default {
     components: {Login, UserPhoto},

--- a/client/src/components/Devices.vue
+++ b/client/src/components/Devices.vue
@@ -1,0 +1,72 @@
+<template lang="pug">
+  .devices
+    v-list(v-if='devices.length > 0')
+      v-list-tile(ripple, @click='selectDevice(device.id)', v-for='(device, index) in devices', :key='index')
+        v-list-tile-content
+          v-list-tile-title {{ device.name }}
+    .empty(v-else) No devices found :(
+    v-btn(flat, large, color="primary", @click='goBack()') Back
+</template>
+
+<script>
+  import SpotifyService from '../services/SpotifyService'
+
+  export default {
+    name: 'devices',
+    data () {
+      return {
+        devices: []
+      }
+    },
+    async created () {
+      // this will update every 2 seconds so that the list updates when we active more players
+      // TODO move to websocket
+      const updateDevices = async () => {
+        this.devices = await SpotifyService.getDevices()
+        this.devices = this.devices.devices.sort(sortByIgnoreCase)
+        setTimeout(updateDevices, 2000)
+
+        // var array = [ "Spotify .5 Web Player", "iPad cua Mac", "Mac's iMac" ]
+
+        function sortByIgnoreCase (a, b) {
+          if (a.toLowerCase < b.toLowerCase) return -1
+          if (a.toLowerCase > b.toLowerCase) return 1
+          return 0
+        }
+      }
+
+      updateDevices()
+    },
+    methods: {
+      selectDevice: function (deviceID) {
+        console.log('switching to', deviceID)
+        SpotifyService.transferPlayback(deviceID, true)
+      },
+      goBack: function () {
+        this.$router.go(-1)
+      }
+    }
+  }
+</script>
+
+<style>
+  .playlist table.datatable.table,
+  .playlist .list {
+    background-color: transparent;
+  }
+</style>
+
+<style scoped>
+  img {
+    width: 100%
+  }
+
+  .no-image {
+    width: 100%;
+    height: 100%;
+    background-color: #c0ffee;
+    line-height:240px;
+    vertical-align: middle;
+    text-align: center;
+  }
+</style>

--- a/client/src/components/Home.vue
+++ b/client/src/components/Home.vue
@@ -1,6 +1,7 @@
 <template lang="pug">
   .callback
     h1 Home
+    v-btn(flat, large, color="primary", @click='goToPickDevice()') Pick Device
     ul(v-if="results")
       li(v-for="item in results.results", v-on:click="goToPlaylist(item)")
         v-container
@@ -30,6 +31,9 @@
     methods: {
       goToPlaylist: function (playlist) {
         this.$router.push({name: 'playlist', params: {id: playlist.id}})
+      },
+      goToPickDevice () {
+        this.$router.push({name: 'devices'})
       }
     }
   }

--- a/client/src/components/Playlist.vue
+++ b/client/src/components/Playlist.vue
@@ -1,5 +1,7 @@
 <template lang="pug">
   .playlist
+    v-btn(flat, large, color="primary", @click='goBack()') Back
+    v-btn(flat, large, color="primary", @click='goToPickDevice()') Pick Device
     v-layout.px-4.pt-4(row, wrap, align-center)
       v-flex(xs12, sm3)
         img.elevation-10(v-if='playlist.images[0]', :src='playlist.images[0].url')
@@ -24,7 +26,6 @@
 
 <script>
   import SpotifyService from '../services/SpotifyService'
-  import WebPlaybackService from '../services/WebPlaybackService'
   import moment from 'moment'
 
   export default {
@@ -64,7 +65,13 @@
     methods: {
       playSong: async function (uri) {
         console.log('Trying to play', uri)
-        WebPlaybackService.playSong(uri)
+        SpotifyService.play(uri)
+      },
+      goToPickDevice () {
+        this.$router.push({name: 'devices'})
+      },
+      goBack: function () {
+        this.$router.go(-1)
       }
     }
   }

--- a/client/src/constants/api.js
+++ b/client/src/constants/api.js
@@ -17,5 +17,8 @@ export default {
   setAuthorizationCode: `${host}/Hooks/set-authorization-code`,
   playlists: `${host}/Hooks/playlists`,
   playlist: (id) => `${host}/Hooks/playlist/${id}`,
-  accessToken: `${host}/Hooks/access-token`
+  transferPlayback: (id, play) => `${host}/Hooks/transferPlayback/${id}/${play}`,
+  play: (spotifyURI) => `${host}/Hooks/play/${spotifyURI}`,
+  accessToken: `${host}/Hooks/access-token`,
+  devices: `${host}/Hooks/devices`
 }

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -3,6 +3,7 @@ import Router from 'vue-router'
 import Landing from '@/components/Landing'
 import Home from '@/components/Home'
 import Playlist from '@/components/Playlist'
+import Devices from '@/components/Devices'
 import User from '../components/User'
 import Users from '../components/Users'
 import Password from '../components/Password'
@@ -49,6 +50,11 @@ export default new Router({
       name: 'playlist',
       props: true,
       component: Playlist
+    },
+    {
+      path: '/devices',
+      name: 'devices',
+      component: Devices
     }
   ]
 })

--- a/client/src/services/SpotifyService.js
+++ b/client/src/services/SpotifyService.js
@@ -14,6 +14,21 @@ class SpotifyService extends BaseService {
     return this.GET(api.accessToken)
   }
 
+  static play (spotifyURI) {
+    return this.POST(api.play(spotifyURI)).then(response => response.results)
+  }
+
+  static transferPlayback (deviceID, play) {
+    const realPlay = typeof play === 'boolean' ? play : false
+    console.log('realPlay', realPlay, 'deviceID', deviceID)
+
+    return this.POST(api.transferPlayback(deviceID, realPlay)).then(response => response.results)
+  }
+
+  static getDevices () {
+    return this.GET(api.devices).then(response => response.results)
+  }
+
   static getPlaylist (playlistID) {
     return this.GET(api.playlist(playlistID)).then(response => response.results)
   }

--- a/client/src/services/WebPlaybackService.js
+++ b/client/src/services/WebPlaybackService.js
@@ -1,37 +1,26 @@
 import BaseService from './BaseService'
 import SpotifyService from './SpotifyService'
 
-const play = ({
-  spotifyURI,
-  playerInstance: {
-    _options: {
-      getOAuthToken,
-      id
-    }
-  }
-}) => {
-  getOAuthToken(accessToken => {
-    fetch(`https://api.spotify.com/v1/me/player/play?device_id=${id}`, {
-      method: 'PUT',
-      body: JSON.stringify({ uris: [spotifyURI] }),
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${accessToken}`
-      }
-    })
-  })
-}
-
 let singletonPlayer
 
 // TODO handle the case where this gets called twice in quick succession
 // if the function is called again before the first one resolves, it could create two players.
 function getPlayer () {
-  // This promise lets us pretend to return in the 'ready' event.
-  return new Promise(async resolve => {
+  // giving it a name so we can recur
+  const getPlayerWithRetries = retriesLeft => async resolve => {
     if (typeof singletonPlayer !== 'undefined') {
       console.log('Returning already-initialized player.')
       resolve(singletonPlayer)
+      return
+    }
+
+    if (!window.Spotify || !window.Spotify.Player) {
+      if (retriesLeft < 1) {
+        // TODO figure out how to fail
+        return
+      }
+
+      setTimeout(() => getPlayerWithRetries(retriesLeft - 1)(resolve), 1000)
       return
     }
 
@@ -58,6 +47,7 @@ function getPlayer () {
       console.log('Ready with Device ID', device_id)
 
       singletonPlayer = player
+      SpotifyService.transferPlayback(player._options.id)
 
       console.log('Returning newly-initialized player.')
       resolve(player)
@@ -65,13 +55,19 @@ function getPlayer () {
 
     // Connect to the player!
     player.connect()
-  })
+  }
+
+  // This promise lets us pretend to return in the 'ready' event.
+  return new Promise(getPlayerWithRetries(3))
 }
 
 class WebPlaybackService extends BaseService {
-  static async playSong (spotifyURI) {
-    const playerInstance = await getPlayer()
-    play({playerInstance, spotifyURI})
+  static initializeWebPlaybackSDK () {
+    getPlayer()
+      .then(player => {
+        console.log('Player initialized successfully.', player)
+      })
+      .catch(error => console.log('Unable to initialize player. Error:', error))
   }
 }
 

--- a/common/models/hook.js
+++ b/common/models/hook.js
@@ -26,11 +26,39 @@ module.exports = function (Hook) {
     })
   }
 
+  Hook.devices = function (cb) {
+    spotify.getDevices().then(results => {
+      cb(null, results)
+    }).catch(error => {
+      console.log('Got error!', error);
+    })
+  }
+
+  Hook.transferPlayback = function (deviceID, play, cb) {
+    console.log("Trying to transfer playback to device", deviceID)
+    spotify.transferPlayback(deviceID, play).then(results => {
+      cb(null, results)
+    }).catch(error => {
+      console.log('caught error when trying to transfer playback.', error)
+    });
+  }
+
+  Hook.play = function (spotifyURI, cb) {
+    console.log("Trying to play", spotifyURI)
+    spotify.play(spotifyURI).then(results => {
+      cb(null, results)
+    }).catch(error => {
+      console.log('caught error when trying to play song', error)
+    });
+  }
+
   Hook.playlist = function (playlistID, cb) {
     console.log("Trying to get playlist ", playlistID)
     spotify.getPlaylist(playlistID).then(results => {
       cb(null, results)
-    }).catch(function(error){console.log('caught', error)});
+    }).catch(error => {
+      console.log('caught error when trying to get playlist', error)
+    });
   }
 
   Hook.remoteMethod('authorizationUrl', {
@@ -49,6 +77,11 @@ module.exports = function (Hook) {
     http: {path: '/set-authorization-code', verb: 'post'}
   })
 
+  Hook.remoteMethod('devices', {
+    returns: {arg: 'results', type: 'object'},
+    http: {path: '/devices', verb: 'get'}
+  })
+
   Hook.remoteMethod('playlists', {
     returns: {arg: 'results', type: 'object'},
     http: {path: '/playlists', verb: 'get'}
@@ -58,5 +91,17 @@ module.exports = function (Hook) {
     accepts: [{arg: 'playlistID', type: 'string'}],
     returns: {arg: 'results', type: 'object'},
     http: {path: '/playlist/:playlistID', verb: 'get'}
+  })
+
+  Hook.remoteMethod('transferPlayback', {
+    accepts: [{arg: 'deviceID', type: 'string'}, {arg: 'play', type: 'boolean'}],
+    returns: {arg: 'results', type: 'object'},
+    http: {path: '/transferPlayback/:deviceID/:play', verb: 'post'}
+  })
+
+  Hook.remoteMethod('play', {
+    accepts: [{arg: 'spotifyURI', type: 'string'}],
+    returns: {arg: 'results', type: 'object'},
+    http: {path: '/play/:spotifyURI', verb: 'post'}
   })
 }

--- a/server/services/spotify-service.js
+++ b/server/services/spotify-service.js
@@ -1,7 +1,7 @@
 const TokenService = require('./token-service')
 const SpotifyWebApi = require('spotify-web-api-node')
 const {clientId, clientSecret, redirectUri} = require('../constants/credentials')
-const scopes = ['streaming', 'user-read-birthdate', 'user-read-email', 'user-read-private', 'playlist-read-private']
+const scopes = ['streaming', 'user-read-birthdate', 'user-read-email', 'user-read-private', 'playlist-read-private', 'user-read-playback-state']
 let spotifyApi
 const limit = 50
 
@@ -42,11 +42,30 @@ module.exports = class SpotifyService {
     })
   }
 
+  play (spotifyURI) {
+    return spotifyApi.play({uris: [ spotifyURI ]})
+      .then(data => data.body)
+  }
+
+  transferPlayback (deviceID, play) {
+    let argsObject = {device_ids: [ deviceID ]}
+    argsObject.play = typeof play === 'boolean' ? play : false
+
+    console.log('Transferring playback with options object', argsObject)
+    
+    return spotifyApi.transferMyPlayback(argsObject)
+      .then(data => data.body)
+  }
+
   getPlaylist (playlistID) {
     // this.setCredentials()
     return spotifyApi.getMe().then(data => {
       return spotifyApi.getPlaylist(data.body.id, playlistID).then(data => data.body)
     })
+  }
+
+  getDevices() {
+    return spotifyApi.getMyDevices().then(data => data.body)
   }
 
   async getPlaylists () {


### PR DESCRIPTION
# Device Selection Page

This adds a v-btn on the top of the playlist list and detail pages that takes you to a page where you can select a device out of the list that spotify gives back from /getMyDevices. Clicking the list tile will call the /transferPlayback method in the Spotify REST API. This method optionally also starts the media. This PR does not try to determine whether the current track is playing or paused. Instead, it always starts playing after /transferPlayback.

# Web Playback SDK?

This PR moves the Web Playback SDK player to a standalone function that sets up the player and registers it with Spotify. The PR then calls /transferPlayback to make the Web Playback SDK player the active device, but does not start playing music. Tapping a song should start the web playback SDK. 

# Music playback

This app no longer plays songs by directly interacting with the Web Playback SDK using JavaScript. Instead, the /play method in the Spotify API will play on the Web Playback SDK (if setup completed successfully.) If the user selects another device, the track will play on that device instead, with the option to switch back to the Web Playback SDK using the same method as any other device. There is a device_id query parameter on /play in the Spotify REST API, but this PR does not make use of it in order to have only one spot where device switches happen.